### PR TITLE
Fix Next.js SSR compatibility by adding 'use client' directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixel-retroui",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A retro-styled UI component library",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-    plugins: [
-        require('tailwindcss'),
-        require('autoprefixer'),
-    ],
+    plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+    },
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -15,6 +15,7 @@ export default [
                 file: 'dist/index.js',
                 format: 'esm',
                 sourcemap: true,
+                banner: "'use client';\n",
             },
         ],
         external: ['react', 'react-dom'],
@@ -24,6 +25,7 @@ export default [
                 declaration: true,
                 declarationDir: 'dist',
                 exclude: ["**/*.test.tsx", "**/*.test.ts"],
+
             }),
             postcss({
                 config: {
@@ -44,7 +46,14 @@ export default [
             }),
             resolve(),
             commonjs(),
-            terser(),
+            terser({
+                format: {
+                    comments: /^\s*('use client'|"use client");/,
+                },
+                compress: {
+                    directives: false,
+                },
+            }),
             copy({
                 targets: [
                     { src: 'fonts/*', dest: 'dist/fonts' }


### PR DESCRIPTION
This PR addresses issue #5 by adding the 'use client' directive to our component bundle via Rollup's banner option.

Changes:
- Added 'use client' directive to the output bundle through Rollup configuration
- Fixed SSR compatibility with Next.js
- Maintains backward compatibility with standard React applications

This resolves the TypeError that users encounter when using our components in Next.js server components.