### PR TITLE
fix: correct font file paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixel-retroui",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixel-retroui",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/src/fonts.css
+++ b/src/fonts.css
@@ -1,14 +1,13 @@
 @font-face {
   font-family: "Minecraft";
-  src: url("/node_modules/pixel-retroui/fonts/Minecraft.otf") format("opentype");
+  src: url("../fonts/Minecraft.otf") format("opentype");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Minecraft";
-  src: url("/node_modules/pixel-retroui/fonts/Minecraft-Bold.otf")
-    format("opentype");
+  src: url("../fonts/Minecraft-Bold.otf") format("opentype");
   font-weight: bold;
   font-style: normal;
 }

--- a/src/retroui.css
+++ b/src/retroui.css
@@ -13,5 +13,3 @@
 body {
   font-family: "Minecraft", sans-serif;
 }
-
-/* You can add more global styles here if needed */


### PR DESCRIPTION
## Problem
Users were experiencing 404 errors when trying to load the Minecraft font files.

## Solution
- Changed font paths in `fonts.css` to use relative paths (`../fonts/`) instead of absolute paths

## Testing
Tested with:
- Local package linking in a Next.js application
- Various package managers (npm, yarn, pnpm)
- Both auto and manual setup options