### PR TITLE
# Enhanced Accordion Component Behavior

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -90,3 +90,31 @@ CustomColors.args = {
     </>
   ),
 };
+
+export const MultipleOpen = Template.bind({});
+MultipleOpen.args = {
+  collapsible: false,
+  children: (
+    <>
+      <AccordionItem value="item-1">
+        <AccordionTrigger>FAQ Item 1</AccordionTrigger>
+        <AccordionContent>
+          <p>With collapsible=false, multiple items can be open at once.</p>
+          <p>Try clicking several headers to see them all open.</p>
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-2">
+        <AccordionTrigger>FAQ Item 2</AccordionTrigger>
+        <AccordionContent>
+          <p>Each item can be toggled independently.</p>
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-3">
+        <AccordionTrigger>FAQ Item 3</AccordionTrigger>
+        <AccordionContent>
+          <p>This mode is useful for FAQ pages or documentation.</p>
+        </AccordionContent>
+      </AccordionItem>
+    </>
+  ),
+};

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -123,7 +123,7 @@ describe("Accordion", () => {
     expect(content2).not.toBeVisible();
   });
 
-  it("keeps at least one item expanded when collapsible is false", () => {
+  it("allows independent toggling of items when collapsible is false", () => {
     renderAccordion({ collapsible: false });
 
     const trigger1 = screen.getByText("Trigger 1");
@@ -131,16 +131,24 @@ describe("Accordion", () => {
     const content1 = screen.getByText("Content 1");
     const content2 = screen.getByText("Content 2");
 
-    fireEvent.click(trigger1);
-    expect(content1).toBeVisible();
-    expect(content2).not.toBeVisible();
-
-    fireEvent.click(trigger1);
-    expect(content1).toBeVisible();
-    expect(content2).not.toBeVisible();
-
-    fireEvent.click(trigger2);
+    // Initially no items are visible
     expect(content1).not.toBeVisible();
+    expect(content2).not.toBeVisible();
+
+    // Click first item to open it
+    fireEvent.click(trigger1);
+    expect(content1).toBeVisible();
+    expect(content2).not.toBeVisible();
+
+    // Click first item again - it should close with the new behavior
+    fireEvent.click(trigger1);
+    expect(content1).not.toBeVisible();
+    expect(content2).not.toBeVisible();
+
+    // Open both items
+    fireEvent.click(trigger1);
+    fireEvent.click(trigger2);
+    expect(content1).toBeVisible();
     expect(content2).toBeVisible();
   });
 
@@ -161,5 +169,33 @@ describe("Accordion", () => {
     fireEvent.click(trigger2);
     expect(trigger1).toHaveAttribute("aria-expanded", "false");
     expect(trigger2).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("allows multiple items to be expanded when collapsible is false", () => {
+    renderAccordion({ collapsible: false });
+
+    const trigger1 = screen.getByText("Trigger 1");
+    const trigger2 = screen.getByText("Trigger 2");
+    const content1 = screen.getByText("Content 1");
+    const content2 = screen.getByText("Content 2");
+
+    // Initially no items are visible
+    expect(content1).not.toBeVisible();
+    expect(content2).not.toBeVisible();
+
+    // Click first item
+    fireEvent.click(trigger1);
+    expect(content1).toBeVisible();
+    expect(content2).not.toBeVisible();
+
+    // Click second item - both should be visible
+    fireEvent.click(trigger2);
+    expect(content1).toBeVisible();
+    expect(content2).toBeVisible();
+
+    // Click first item again - it should close
+    fireEvent.click(trigger1);
+    expect(content1).not.toBeVisible();
+    expect(content2).toBeVisible();
   });
 });


### PR DESCRIPTION
# Enhanced Accordion Component Behavior

## What's Changed

This PR improves the Accordion component by fixing the `collapsible` prop behaviour:

- **When `collapsible={true}` (default)**: Classic accordion behaviour where only one item can be open at a time. 

- **When `collapsible={false}`**: Independent sections behaviour where multiple items can be open simultaneously. 
- 
## Additional Changes

- Added and updated tests to verify both behaviour
- Added a new MultipleOpen example in Storybook to demonstrate the independent sections mode
- Updated component state management to track multiple active items when needed

## Testing

The changes have been tested in:
- Jest test suite
- Storybook
- Next.js project using npm link

## Breaking Changes

No breaking changes for existing usage. The default behaviour (`collapsible={true}`) remains the same.

## Screenshots/Examples
<img width="575" alt="Screenshot 2025-04-07 at 12 30 18 PM" src="https://github.com/user-attachments/assets/b3d2ed9e-ca8e-427f-bf3a-6af2d04c95d6" />

### Example (`collapsible={true}`)
```jsx
<Accordion collapsible={true}>
  <AccordionItem value="item-1">
    <AccordionTrigger>Section 1</AccordionTrigger>
    <AccordionContent>Only one section open at a time</AccordionContent>
  </AccordionItem>
  <AccordionItem value="item-2">
    <AccordionTrigger>Section 2</AccordionTrigger>
    <AccordionContent>Opens and closes other sections</AccordionContent>
  </AccordionItem>
</Accordion>